### PR TITLE
Valid airdrop file

### DIFF
--- a/utils/isValidAirdropFile.ts
+++ b/utils/isValidAirdropFile.ts
@@ -42,6 +42,11 @@ const isValidAirdropFile = (file: AirdropFileProps) => {
     return false
   }
   if (
+    file.startType !== 'timestamp'
+  ) { 
+    toast.error( 'start or expiration must be a number' )
+    }
+  if (
     file.expirationType !== 'timestamp' &&
     file.expirationType !== 'height' &&
     file.expirationType !== null

--- a/utils/isValidAirdropFile.ts
+++ b/utils/isValidAirdropFile.ts
@@ -42,13 +42,12 @@ const isValidAirdropFile = (file: AirdropFileProps) => {
     toast.error('Start type must be timestamp or height or null')
     return false
   }
-  
-  if ( typeof start === 'string') {
-    toast.error('startType needs to be a Number')
+
+  if (typeof file.start === 'string') {
+    toast.error('start and expiration needs to be a Number')
     return false
   }
-  
-  
+
   if (file.startType !== 'timestamp') {
     toast.error('start or expiration must be a number')
   }
@@ -58,6 +57,10 @@ const isValidAirdropFile = (file: AirdropFileProps) => {
     file.expirationType !== null
   ) {
     toast.error('Expiration Type must be timestamp or height or null')
+    return false
+  }
+  if (typeof file.expiration === 'string') {
+    toast.error('start and expiration needs to be a Number')
     return false
   }
   if (

--- a/utils/isValidAirdropFile.ts
+++ b/utils/isValidAirdropFile.ts
@@ -1,4 +1,5 @@
 import toast from 'react-hot-toast'
+import { start } from 'repl'
 import { isValidAddress } from './isValidAddress'
 
 interface AccountProps {
@@ -41,6 +42,13 @@ const isValidAirdropFile = (file: AirdropFileProps) => {
     toast.error('Start type must be timestamp or height or null')
     return false
   }
+  
+  if ( typeof start === 'string') {
+    toast.error('startType needs to be a Number')
+    return false
+  }
+  
+  
   if (file.startType !== 'timestamp') {
     toast.error('start or expiration must be a number')
   }

--- a/utils/isValidAirdropFile.ts
+++ b/utils/isValidAirdropFile.ts
@@ -1,5 +1,4 @@
 import toast from 'react-hot-toast'
-
 import { isValidAddress } from './isValidAddress'
 
 interface AccountProps {

--- a/utils/isValidAirdropFile.ts
+++ b/utils/isValidAirdropFile.ts
@@ -1,4 +1,5 @@
 import toast from 'react-hot-toast'
+
 import { isValidAddress } from './isValidAddress'
 
 interface AccountProps {
@@ -41,11 +42,9 @@ const isValidAirdropFile = (file: AirdropFileProps) => {
     toast.error('Start type must be timestamp or height or null')
     return false
   }
-  if (
-    file.startType !== 'timestamp'
-  ) { 
-    toast.error( 'start or expiration must be a number' )
-    }
+  if (file.startType !== 'timestamp') {
+    toast.error('start or expiration must be a number')
+  }
   if (
     file.expirationType !== 'timestamp' &&
     file.expirationType !== 'height' &&


### PR DESCRIPTION


Add toast error that [shows] "Start or expiration must be a number" 

![Screenshot 2022-02-12 at 17 24 01](https://user-images.githubusercontent.com/68139321/153721943-e1861d62-3bb2-491e-aba0-0876c6921d40.png)


created `if statement` that if timestamp is inputed to either startType or expirationType it will throw a toast error. 

The more i work on this the more i think we could expand further but would like some of the senior devs views on this. 
