### PR TITLE
fix(styles): remove unused css import

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Description

This PR removes an unused stylesheet import for a previously used font family.

## Changes

\-

## Screenshots

\-

## Testing Steps

\-

## Links

\-
