### PR TITLE
feat(pages): improve seo

### DIFF
--- a/components/DefaultAppSeo.tsx
+++ b/components/DefaultAppSeo.tsx
@@ -1,0 +1,30 @@
+import meta from 'config/meta'
+import { useRouter } from 'next/router'
+import { DefaultSeo } from 'next-seo'
+
+const DefaultAppSeo = () => {
+  const router = useRouter()
+
+  return (
+    <DefaultSeo
+      canonical={meta.url + (router.asPath || '')}
+      defaultTitle={meta.name}
+      description={meta.description}
+      openGraph={{
+        title: meta.name,
+        description: meta.description,
+        type: 'website',
+        site_name: meta.name,
+        images: [{ url: '/social.png' }],
+      }}
+      titleTemplate={`%s | ${meta.name}`}
+      twitter={{
+        cardType: 'summary_large_image',
+        handle: meta.twitter.username,
+        site: meta.twitter.username,
+      }}
+    />
+  )
+}
+
+export default DefaultAppSeo

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -3,26 +3,8 @@ import Head from 'next/head'
 import { ReactNode } from 'react'
 import { PageMetadata } from 'utils/layout'
 
+import DefaultAppSeo from './DefaultAppSeo'
 import Sidebar from './Sidebar'
-
-const DefaultSeo = () => {
-  return (
-    <>
-      <Head>
-        {/* TODO: remove hardcoded title */}
-        <title>JunoTools</title>
-        <meta
-          content="minimum-scale=1, initial-scale=1, width=device-width"
-          name="viewport"
-        />
-        <meta name="description" content="Tooling dApp for Juno Network" />
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
-
-      {/* TODO: add exhaustive seo defaults */}
-    </>
-  )
-}
 
 export interface LayoutProps {
   metadata?: PageMetadata
@@ -32,7 +14,14 @@ export interface LayoutProps {
 const Layout = ({ children, metadata = {} }: LayoutProps) => {
   return (
     <div className="overflow-hidden relative">
-      <DefaultSeo />
+      <Head>
+        <meta
+          content="minimum-scale=1, initial-scale=1, width=device-width"
+          name="viewport"
+        />
+      </Head>
+
+      <DefaultAppSeo />
 
       {/* plumbus confetti */}
       <div className="fixed inset-0 -z-10 pointer-events-none juno-gradient-bg">

--- a/config/meta.ts
+++ b/config/meta.ts
@@ -1,0 +1,11 @@
+const meta = {
+  name: 'JunoTools',
+  description: `JunoTools is a swiss knife that helps you build on Juno by providing smart contract front ends`,
+  domain: 'juno.tools',
+  url: 'https://juno.tools',
+  twitter: {
+    username: '@junotools',
+  },
+}
+
+export default meta

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "compare-versions": "^4",
     "match-sorter": "^6",
     "next": "^12",
+    "next-seo": "^4",
     "next-transpile-modules": "^9",
     "react": "^17",
     "react-datetime-picker": "^3",

--- a/pages/airdrops/[address]/claim.tsx
+++ b/pages/airdrops/[address]/claim.tsx
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import { useWallet } from 'contexts/wallet'
 import { useRouter } from 'next/router'
+import { NextSeo } from 'next-seo'
 import React, { useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 import SyntaxHighlighter from 'react-syntax-highlighter'
@@ -89,6 +90,8 @@ const ClaimDrop = ({ address }: { address: string }) => {
 
   return (
     <div className="w-3/4 h-3/4">
+      <NextSeo title="Claim Airdrop" />
+
       <h1 className="mb-20 text-6xl font-bold text-center">{name}</h1>
 
       <h1 className="mb-10 text-3xl font-bold text-center">

--- a/pages/airdrops/create.tsx
+++ b/pages/airdrops/create.tsx
@@ -8,6 +8,7 @@ import { useContracts } from 'contexts/contracts'
 import { useWallet } from 'contexts/wallet'
 import type { NextPage } from 'next'
 import Router from 'next/router'
+import { NextSeo } from 'next-seo'
 import React, { useEffect, useRef, useState } from 'react'
 import DateTimePicker from 'react-datetime-picker/dist/entry.nostyle'
 import toast from 'react-hot-toast'
@@ -264,6 +265,8 @@ const CreateAirdrop: NextPage = () => {
 
   return (
     <div className="py-6 px-12 space-y-8">
+      <NextSeo title="Create Airdrop" />
+
       <div className="space-y-4">
         <h1 className="text-4xl font-bold">Create Airdrop</h1>
         <p>

--- a/pages/airdrops/fund.tsx
+++ b/pages/airdrops/fund.tsx
@@ -2,6 +2,7 @@ import axios from 'axios'
 import { useWallet } from 'contexts/wallet'
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
+import { NextSeo } from 'next-seo'
 import React, { useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 import SyntaxHighlighter from 'react-syntax-highlighter'
@@ -136,6 +137,7 @@ const FundAirdrop: NextPage = () => {
 
   return (
     <div className="w-3/4 h-4/4">
+      <NextSeo title="Fund Airdrop" />
       <h1 className="mb-6 text-6xl font-bold text-center">Fund Airdrop</h1>
       {balance === null ? (
         <div className="my-5 text-xl font-bold text-center">

--- a/pages/airdrops/index.tsx
+++ b/pages/airdrops/index.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx'
 import Anchor from 'components/Anchor'
 import { NextPage } from 'next'
+import { NextSeo } from 'next-seo'
 import { FaHatWizard } from 'react-icons/fa'
 import { GiPayMoney } from 'react-icons/gi'
 
@@ -22,6 +23,8 @@ const routes = [
 const AirdropsPage: NextPage = () => {
   return (
     <section className="py-6 px-12 space-y-4 text-center">
+      <NextSeo title="Airdrops" />
+
       <h1 className="text-4xl font-bold">Airdrop Tokens</h1>
 
       <p className="text-xl">

--- a/pages/airdrops/list.tsx
+++ b/pages/airdrops/list.tsx
@@ -6,6 +6,7 @@ import SearchInput from 'components/SearchInput'
 import { useWallet } from 'contexts/wallet'
 import { matchSorter } from 'match-sorter'
 import { NextPage } from 'next'
+import { NextSeo } from 'next-seo'
 import { useMemo, useState } from 'react'
 import toast from 'react-hot-toast'
 import { CgSpinnerAlt } from 'react-icons/cg'
@@ -45,6 +46,8 @@ const AirdropListPage: NextPage = () => {
 
   return (
     <section className="flex flex-col px-12 pt-6 space-y-4 h-screen">
+      <NextSeo title="Airdrops List" />
+
       {/* header section */}
       <div className="flex items-center space-x-4">
         <h1 className="text-4xl font-bold">Airdrops</h1>

--- a/pages/airdrops/manage.tsx
+++ b/pages/airdrops/manage.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx'
 import Anchor from 'components/Anchor'
 import type { NextPage } from 'next'
+import { NextSeo } from 'next-seo'
 import React from 'react'
 import { FaAsterisk, FaBullseye, FaBurn } from 'react-icons/fa'
 
@@ -27,6 +28,8 @@ const routes = [
 const ManageAirdropsPage: NextPage = () => {
   return (
     <section className="py-6 px-12 space-y-4 text-center">
+      <NextSeo title="Manage Airdrop" />
+
       <h1 className="text-4xl font-bold">Manage Airdrops</h1>
 
       <p className="text-xl">

--- a/pages/airdrops/register.tsx
+++ b/pages/airdrops/register.tsx
@@ -2,6 +2,7 @@ import axios from 'axios'
 import { useWallet } from 'contexts/wallet'
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
+import { NextSeo } from 'next-seo'
 import React, { useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 import SyntaxHighlighter from 'react-syntax-highlighter'
@@ -110,6 +111,7 @@ const RegisterAirdrop: NextPage = () => {
 
   return (
     <div className="w-3/4 h-4/4">
+      <NextSeo title="Register Airdrop" />
       <h1 className="text-6xl font-bold text-center">Register Airdrop</h1>
       <div className="my-6">
         <label className="block mb-2 text-lg font-bold text-center text-gray-900 dark:text-gray-300">

--- a/yarn.lock
+++ b/yarn.lock
@@ -4350,6 +4350,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+next-seo@^4:
+  version "4.29.0"
+  resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-4.29.0.tgz#d281e95ba47914117cc99e9e468599f0547d9b9b"
+  integrity sha512-xmwzcz4uHaYJ8glbuhs6FSBQ7z3irmdPYdJJ5saWm72Uy3o+mPKGaPCXQetTCE6/xxVnpoDV4yFtFlEjUcljSg==
+
 next-transpile-modules@^9:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-9.0.0.tgz#133b1742af082e61cc76b02a0f12ffd40ce2bf90"


### PR DESCRIPTION
Partially fixes #9

## Description

This PR adds default SEO values and pages titles throughout airdrop pages.

## Changes

List any technical changes.

- [x] add `next-seo` dependency
- [x] add default seo values
- [x] add page titles on airdrop pages

## Screenshots

<img width="422" alt="image" src="https://user-images.githubusercontent.com/8220954/154761358-ca472946-93df-4a89-8ab0-db2b5a6e41ad.png">

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- [x] visit airdrop pages and check whether page has updates titles in browser page/tab

## Links

\-
