### PR TITLE
feat(ui): add notice on small viewports

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx'
 import Head from 'next/head'
 import { ReactNode } from 'react'
+import { FaDesktop } from 'react-icons/fa'
 import { PageMetadata } from 'utils/layout'
 
 import Sidebar from './Sidebar'
@@ -44,7 +45,7 @@ const Layout = ({ children, metadata = {} }: LayoutProps) => {
       </div>
 
       {/* actual layout container */}
-      <div className="flex">
+      <div className="hidden sm:flex">
         <Sidebar />
         <main
           className={clsx('overflow-auto relative flex-grow h-screen', {
@@ -54,6 +55,16 @@ const Layout = ({ children, metadata = {} }: LayoutProps) => {
         >
           {children}
         </main>
+      </div>
+
+      <div className="flex flex-col justify-center items-center p-8 space-y-4 h-screen text-center bg-black/50 sm:hidden">
+        <FaDesktop size={48} />
+        <h1 className="text-2xl font-bold">Unsupported Viewport</h1>
+        <p>
+          JunoTools is best viewed on the big screen.
+          <br />
+          Please open JunoTools on your tablet or desktop browser.
+        </p>
       </div>
     </div>
   )


### PR DESCRIPTION
Fixes #38

## Description

This PR adds a blocker notice on small viewports.

## Changes

List any technical changes.

\-

## Screenshots

![](https://media.discordapp.net/attachments/933515307597848656/944344728659460126/unknown.png)

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- [x] reduce viewport smaller than common tablets
- [x] blocker notice should be visible

## Links

\-
