### PR TITLE
feat(ui): create airdrops stepper component

### DIFF
--- a/components/AirdropsStepper.tsx
+++ b/components/AirdropsStepper.tsx
@@ -1,0 +1,64 @@
+import clsx from 'clsx'
+
+import Anchor from './Anchor'
+
+/**
+ * Airdrops page steps defined with step name and page route
+ */
+export const steps = [
+  { name: 'Configure', href: '/airdrops/create' },
+  { name: 'Escrow', href: '/airdrops/escrow' },
+  { name: 'Register', href: '/airdrops/register' },
+  { name: 'Fund', href: '/airdrops/fund' },
+] as const
+
+export interface AirdropsStepperProps {
+  step: number
+}
+
+const AirdropsStepper = (props: AirdropsStepperProps) => {
+  const { step } = props
+
+  if (!(step > 0 && step <= steps.length)) {
+    throw new Error('AirdropsStepperError: invalid step value')
+  }
+
+  return (
+    <ol className="flex items-center pb-8 text-center">
+      {steps.map(({ name, href }, i) => (
+        <li key={`step-${name}`} className="relative pr-24 last:pr-0">
+          {/* horizontal line */}
+          {i + 1 < steps.length && (
+            <div
+              className="flex absolute inset-0 left-10 items-center"
+              aria-hidden="true"
+            >
+              <div className="w-full h-0.5 bg-juno" />
+            </div>
+          )}
+          {/* anchor step */}
+          <Anchor
+            href={href}
+            className={clsx(
+              'group flex relative justify-center items-center w-10 h-10 rounded-full',
+              'border-2 border-plumbus',
+              i < step ? 'bg-plumbus' : 'bg-transparent hover:bg-plumbus/25'
+            )}
+          >
+            <span className="font-bold">{i + 1}</span>
+            <span
+              className={clsx(
+                'absolute -bottom-8 pt-4 text-sm group-hover:underline',
+                { 'font-bold': i + 1 == step }
+              )}
+            >
+              {name}
+            </span>
+          </Anchor>
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+export default AirdropsStepper

--- a/pages/airdrops/create.tsx
+++ b/pages/airdrops/create.tsx
@@ -2,6 +2,7 @@ import { fromAscii, toAscii } from '@cosmjs/encoding'
 import axios from 'axios'
 import clsx from 'clsx'
 import { compare } from 'compare-versions'
+import AirdropsStepper from 'components/AirdropsStepper'
 import Anchor from 'components/Anchor'
 import TooltipIcon from 'components/TooltipIcon'
 import { useContracts } from 'contexts/contracts'
@@ -267,13 +268,16 @@ const CreateAirdrop: NextPage = () => {
     <div className="py-6 px-12 space-y-8">
       <NextSeo title="Create Airdrop" />
 
-      <div className="space-y-4">
+      <div className="space-y-8 text-center">
         <h1 className="text-4xl font-bold">Create Airdrop</h1>
+        <div className="flex justify-center">
+          <AirdropsStepper step={1} />
+        </div>
         <p>
           Make sure you check our{' '}
           <Anchor
             href={AIRDROP_CREATE_DOCS}
-            className="font-bold text-plumbus-40"
+            className="font-bold text-plumbus hover:underline"
           >
             documentation
           </Anchor>{' '}


### PR DESCRIPTION
Resolve #50

## Description

This PR creates an `<AirdropsStepper />` component to navigate between airdrop creation pages.

## Changes

List any technical changes.

- [x] added `AirdropsStepper` component
- [x] added stepper in `/airdrops/create` page

## Screenshots

![stepper](https://cdn.discordapp.com/attachments/933515307597848656/946121940412821594/stepper.gif)

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- [x] click steps to navigate between airdrop creation pages

## Links

\-
