### PR TITLE
refactor(pages): rework airdrops fund page

### DIFF
--- a/components/Radio.tsx
+++ b/components/Radio.tsx
@@ -1,8 +1,8 @@
 import { ChangeEventHandler, ReactNode } from 'react'
 
-export interface AirdropsStartEndRadioProps {
+export interface RadioProps<T = string> {
   id: string
-  htmlFor: 'start' | 'end'
+  htmlFor: T
   title: string
   subtitle: string
   checked: boolean
@@ -11,14 +11,14 @@ export interface AirdropsStartEndRadioProps {
   children?: ReactNode
 }
 
-const AirdropsStartEndRadio = (props: AirdropsStartEndRadioProps) => {
+const Radio = (props: RadioProps) => {
   const { id, htmlFor, title, subtitle, checked, onChange, children } = props
   return (
     <div className="flex space-x-4 w-full">
       {/* radio element */}
       <input
         id={`${htmlFor}-${id}`}
-        name={`${htmlFor}-type`}
+        name={htmlFor}
         type="radio"
         className="mt-1 w-4 h-4 text-plumbus focus:ring-plumbus cursor-pointer form-radio"
         onChange={onChange}
@@ -29,7 +29,7 @@ const AirdropsStartEndRadio = (props: AirdropsStartEndRadioProps) => {
         {/* radio description */}
         <label htmlFor={`${htmlFor}-${id}`} className="group cursor-pointer">
           <span className="block font-bold group-hover:underline">{title}</span>
-          <span className="block text-sm">{subtitle}</span>
+          <span className="block text-sm whitespace-pre-wrap">{subtitle}</span>
         </label>
 
         {/* children if checked */}
@@ -39,4 +39,4 @@ const AirdropsStartEndRadio = (props: AirdropsStartEndRadioProps) => {
   )
 }
 
-export default AirdropsStartEndRadio
+export default Radio

--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -1,0 +1,31 @@
+import clsx from 'clsx'
+import { ReactNode } from 'react'
+
+export interface StatsProps {
+  title: string
+  children: ReactNode
+}
+
+const Stats = ({ title, children }: StatsProps) => {
+  return (
+    <div
+      className={clsx(
+        'flex flex-col p-6 space-y-1',
+        'bg-white/10 rounded border-2 border-white/20 backdrop-blur'
+      )}
+    >
+      <div className="font-bold text-white/50">{title}</div>
+      <div className="text-4xl font-bold">{children}</div>
+    </div>
+  )
+}
+
+export interface StatsDenomProps {
+  text: ReactNode
+}
+
+Stats.Denom = function StatsDenom({ text }: StatsDenomProps) {
+  return <span className="font-mono text-xl">{text}</span>
+}
+
+export default Stats

--- a/pages/airdrops/create.tsx
+++ b/pages/airdrops/create.tsx
@@ -2,12 +2,12 @@ import { fromAscii, toAscii } from '@cosmjs/encoding'
 import axios from 'axios'
 import clsx from 'clsx'
 import { compare } from 'compare-versions'
-import AirdropsStartEndRadio from 'components/AirdropsStartEndRadio'
 import AirdropsStepper from 'components/AirdropsStepper'
 import Anchor from 'components/Anchor'
 import FormControl from 'components/FormControl'
 import Input from 'components/Input'
 import InputDateTime from 'components/InputDateTime'
+import Radio from 'components/Radio'
 import { useContracts } from 'contexts/contracts'
 import { useWallet } from 'contexts/wallet'
 import type { NextPage } from 'next'
@@ -360,7 +360,7 @@ const CreateAirdropPage: NextPage = () => {
         >
           <fieldset className="p-4 space-y-4 rounded border-2 border-white/25">
             {START_RADIO_VALUES.map(({ id, title, subtitle }) => (
-              <AirdropsStartEndRadio
+              <Radio
                 key={`start-${id}`}
                 id={id}
                 htmlFor="start"
@@ -384,7 +384,7 @@ const CreateAirdropPage: NextPage = () => {
                     value={startDate ?? undefined}
                   />
                 )}
-              </AirdropsStartEndRadio>
+              </Radio>
             ))}
           </fieldset>
         </FormControl>
@@ -396,7 +396,7 @@ const CreateAirdropPage: NextPage = () => {
         >
           <fieldset className="p-4 space-y-4 rounded border-2 border-white/25">
             {END_RADIO_VALUES.map(({ id, title, subtitle }) => (
-              <AirdropsStartEndRadio
+              <Radio
                 key={`end-${id}`}
                 id={id}
                 htmlFor="end"
@@ -420,7 +420,7 @@ const CreateAirdropPage: NextPage = () => {
                     value={expirationDate ?? undefined}
                   />
                 )}
-              </AirdropsStartEndRadio>
+              </Radio>
             ))}
           </fieldset>
         </FormControl>


### PR DESCRIPTION
## Description

This PR updates the airdrops fund page.

## Changes

List any technical changes.

- [x] make existing airdrops radio component reusable eveywhere
- [x] create stats component
- [x] rework airdrops fund page
- [ ] update escrow step styling [^1]

## Screenshots

![](https://cdn.discordapp.com/attachments/933515307597848656/949029564460433428/CleanShot_2022-03-04_at_02.43.07.gif)

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- copy an airdrop address from `/airdrops` and test in `/airdrops/fund`

## Links

Add links to Figma files, documentation, etc.

[^1]: See #58 and #66