### PR TITLE
refactor(pages): rework airdrop escrow page

### DIFF
--- a/components/AirdropEscrowStatus.tsx
+++ b/components/AirdropEscrowStatus.tsx
@@ -1,0 +1,63 @@
+import clsx from 'clsx'
+import Anchor from 'components/Anchor'
+import FormControl from 'components/FormControl'
+import StackedList from 'components/StackedList'
+import { AirdropProps, ESCROW_AMOUNT } from 'utils/constants'
+import { ellipsis } from 'utils/text'
+
+export interface AirdropEscrowStatusProps {
+  airdrop: AirdropProps
+  contractAddress?: string
+}
+
+const AirdropEscrowStatus = (props: AirdropEscrowStatusProps) => {
+  const { airdrop, contractAddress = '' } = props
+
+  return (
+    <FormControl
+      title="Airdrop escrow status"
+      subtitle="View current CW20 token airdrop statistics."
+    >
+      <StackedList>
+        <StackedList.Item name="Escrow Status">
+          <span
+            className={clsx(
+              'block font-bold',
+              airdrop?.escrow ? 'text-plumbus' : 'text-green-500'
+            )}
+          >
+            {airdrop?.escrow
+              ? airdrop.escrowStatus ?? 'Not Completed'
+              : 'Completed'}
+          </span>
+          {!airdrop?.escrow && (
+            <span className="block text-sm">
+              Your escrow is completed, you may now continue to{' '}
+              <Anchor
+                href={`/airdrops/register/?contractAddress=${contractAddress}`}
+                className="font-bold text-plumbus hover:underline"
+              >
+                register your airdrop
+              </Anchor>
+              .
+            </span>
+          )}
+        </StackedList.Item>
+
+        <StackedList.Item name="Escrow Deposit">
+          {ESCROW_AMOUNT} juno
+        </StackedList.Item>
+
+        <StackedList.Item name="Airdrop Status" className="capitalize">
+          {airdrop?.status ?? '...'}
+        </StackedList.Item>
+
+        <StackedList.Item name="Processing" className="capitalize">
+          {ellipsis(airdrop?.processing, String(airdrop?.processing))}
+        </StackedList.Item>
+      </StackedList>
+    </FormControl>
+  )
+}
+
+export default AirdropEscrowStatus

--- a/components/AirdropStatus.tsx
+++ b/components/AirdropStatus.tsx
@@ -3,23 +3,22 @@ import Anchor from 'components/Anchor'
 import FormControl from 'components/FormControl'
 import StackedList from 'components/StackedList'
 import { AirdropProps, ESCROW_AMOUNT } from 'utils/constants'
-import { ellipsis } from 'utils/text'
 
-export interface AirdropEscrowStatusProps {
+export interface AirdropStatusProps {
   airdrop: AirdropProps
   contractAddress?: string
 }
 
-const AirdropEscrowStatus = (props: AirdropEscrowStatusProps) => {
+const AirdropStatus = (props: AirdropStatusProps) => {
   const { airdrop, contractAddress = '' } = props
 
   return (
     <FormControl
-      title="Airdrop escrow status"
-      subtitle="View current CW20 token airdrop statistics."
+      title="Airdrop status"
+      subtitle="View current airdrop statistics."
     >
       <StackedList>
-        <StackedList.Item name="Escrow Status">
+        <StackedList.Item name="Escrow Status" className="capitalize">
           <span
             className={clsx(
               'block font-bold',
@@ -27,7 +26,9 @@ const AirdropEscrowStatus = (props: AirdropEscrowStatusProps) => {
             )}
           >
             {airdrop?.escrow
-              ? airdrop.escrowStatus ?? 'Not Completed'
+              ? airdrop?.escrowStatus === 'waiting'
+                ? 'Not Completed'
+                : 'Deposited'
               : 'Completed'}
           </span>
           {!airdrop?.escrow && (
@@ -48,16 +49,12 @@ const AirdropEscrowStatus = (props: AirdropEscrowStatusProps) => {
           {ESCROW_AMOUNT} juno
         </StackedList.Item>
 
-        <StackedList.Item name="Airdrop Status" className="capitalize">
+        <StackedList.Item name="Airdrop Latest Step" className="capitalize">
           {airdrop?.status ?? '...'}
-        </StackedList.Item>
-
-        <StackedList.Item name="Processing" className="capitalize">
-          {ellipsis(airdrop?.processing, String(airdrop?.processing))}
         </StackedList.Item>
       </StackedList>
     </FormControl>
   )
 }
 
-export default AirdropEscrowStatus
+export default AirdropStatus

--- a/components/Alert.tsx
+++ b/components/Alert.tsx
@@ -1,0 +1,46 @@
+import clsx from 'clsx'
+import { DetailedHTMLProps, HTMLAttributes, ReactNode, useState } from 'react'
+import { FaExclamationTriangle, FaInfoCircle, FaTimes } from 'react-icons/fa'
+import { IconType } from 'react-icons/lib'
+
+type BaseProps<T = HTMLDivElement> = DetailedHTMLProps<HTMLAttributes<T>, T>
+
+export type AlertType = 'info' | 'warning' | 'error' | 'ghost'
+
+const ALERT_ICONS_MAP: Record<AlertType, IconType | null> = {
+  info: FaInfoCircle,
+  warning: FaExclamationTriangle,
+  error: FaTimes,
+  ghost: null,
+}
+
+export interface AlertProps extends BaseProps {
+  type?: AlertType
+}
+
+const Alert = (props: AlertProps) => {
+  const { type = 'info', className, children, ...rest } = props
+  const AlertIcon = ALERT_ICONS_MAP[type]
+
+  return (
+    <div
+      className={clsx(
+        'flex relative p-4 space-x-4 border-l-4',
+        { 'bg-blue-500/25 border-blue-500': type == 'info' },
+        { 'bg-yellow-500/25 border-yellow-500': type == 'warning' },
+        { 'bg-red-500/25 border-red-500': type == 'error' },
+        { 'bg-stone-500/25 border-stone-500': type == 'ghost' },
+        className
+      )}
+      {...rest}
+    >
+      {AlertIcon && <AlertIcon size={24} />}
+      <div className="flex flex-col flex-grow space-y-2">
+        {children}
+        {/*  */}
+      </div>
+    </div>
+  )
+}
+
+export default Alert

--- a/components/Conditional.tsx
+++ b/components/Conditional.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react'
+
+export interface ConditionalProps {
+  test: boolean
+  children: ReactNode
+}
+
+const Conditional = ({ test, children }: ConditionalProps) => {
+  if (!test) return null
+  return <>{children}</>
+}
+
+export default Conditional

--- a/components/Conditional.tsx
+++ b/components/Conditional.tsx
@@ -1,12 +1,12 @@
 import { ReactNode } from 'react'
 
 export interface ConditionalProps {
-  test: boolean
+  test: any
   children: ReactNode
 }
 
 const Conditional = ({ test, children }: ConditionalProps) => {
-  if (!test) return null
+  if (!Boolean(test)) return null
   return <>{children}</>
 }
 

--- a/components/StackedList.tsx
+++ b/components/StackedList.tsx
@@ -1,0 +1,42 @@
+import clsx from 'clsx'
+import { DetailedHTMLProps, HTMLAttributes, ReactNode } from 'react'
+
+type BaseProps<T = HTMLDListElement> = DetailedHTMLProps<HTMLAttributes<T>, T>
+
+export interface StackedListProps extends BaseProps {
+  children: ReactNode
+}
+
+const StackedList = (props: StackedListProps) => {
+  const { className, ...rest } = props
+
+  return (
+    <dl
+      className={clsx(
+        'bg-white/5 rounded border-2 border-white/25',
+        'divide-y-2 divide-white/25',
+        className
+      )}
+      {...rest}
+    />
+  )
+}
+
+type BaseItemProps<T = HTMLElement> = DetailedHTMLProps<HTMLAttributes<T>, T>
+
+export interface StackedListItemProps extends BaseItemProps {
+  name: ReactNode
+}
+
+StackedList.Item = function StackedListItem(props: StackedListItemProps) {
+  const { name, className, ...rest } = props
+
+  return (
+    <div className="grid grid-cols-3 py-3 px-4 hover:bg-white/5">
+      <dd className="font-medium text-white/50">{name}</dd>
+      <dt className={clsx('col-span-2', className)} {...rest} />
+    </div>
+  )
+}
+
+export default StackedList

--- a/components/StackedList.tsx
+++ b/components/StackedList.tsx
@@ -7,7 +7,7 @@ export interface StackedListProps extends BaseProps {
   children: ReactNode
 }
 
-const StackedList = (props: StackedListProps) => {
+const StackedList: React.FC<BaseProps> = (props) => {
   const { className, ...rest } = props
 
   return (

--- a/components/StackedList.tsx
+++ b/components/StackedList.tsx
@@ -7,7 +7,7 @@ export interface StackedListProps extends BaseProps {
   children: ReactNode
 }
 
-const StackedList: React.FC<BaseProps> = (props) => {
+const StackedList = (props: StackedListProps) => {
   const { className, ...rest } = props
 
   return (

--- a/pages/airdrops/escrow.tsx
+++ b/pages/airdrops/escrow.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import clsx from 'clsx'
-import AirdropEscrowStatus from 'components/AirdropEscrowStatus'
 import AirdropsStepper from 'components/AirdropsStepper'
+import AirdropStatus from 'components/AirdropStatus'
 import Alert from 'components/Alert'
 import Anchor from 'components/Anchor'
 import Conditional from 'components/Conditional'
@@ -44,6 +44,7 @@ const EscrowAirdropPage: NextPage = () => {
       setContractAddress(router.query.contractAddress)
   }, [router.query])
 
+  /* TODO: Send a request every 5 mins */
   useEffect(() => {
     if (contractAddress !== '') {
       axios
@@ -85,10 +86,6 @@ const EscrowAirdropPage: NextPage = () => {
       setLoading(false)
       toast.error(err.message, { style: { maxWidth: 'none' } })
     }
-  }
-
-  if (__DEV__) {
-    console.log(airdrop)
   }
 
   /**
@@ -152,17 +149,17 @@ const EscrowAirdropPage: NextPage = () => {
         {!airdrop && (
           <Alert type="ghost">
             <p>
-              To combat spam, we require a small deposit of <b>0.1 Juno</b>{' '}
-              before your airdrop can be created.
+              To combat spam, we require a small deposit of{' '}
+              <b>{ESCROW_AMOUNT} juno</b> before your airdrop can be created.
               <br />
               You will get this deposit returned to you when your airdrop is
-              registered and funded.
+              registered.
               <br />
               <br />
               You can read more about the escrow process on the{' '}
               <Anchor
-                href={links.Docs}
-                className="text-plumbus hover:underline"
+                href={links['Docs Create Airdrop']}
+                className="font-bold text-plumbus hover:underline"
               >
                 documentation page
               </Anchor>
@@ -171,11 +168,8 @@ const EscrowAirdropPage: NextPage = () => {
           </Alert>
         )}
 
-        {airdrop && !airdrop.escrowStatus && (
-          <AirdropEscrowStatus
-            airdrop={airdrop}
-            contractAddress={contractAddress}
-          />
+        {airdrop && (
+          <AirdropStatus airdrop={airdrop} contractAddress={contractAddress} />
         )}
 
         {airdrop && (
@@ -193,7 +187,7 @@ const EscrowAirdropPage: NextPage = () => {
                 <FaArrowRight />
               </Anchor>
             )}
-            {airdrop.escrow && !airdrop.escrowStatus && (
+            {airdrop.escrow && airdrop?.escrowStatus === 'waiting' && (
               <button
                 disabled={loading}
                 className={clsx(

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -68,4 +68,5 @@ export interface AirdropProps {
   processing?: boolean
   escrow?: boolean
   escrowStatus?: string
+  status?: string
 }

--- a/utils/text.ts
+++ b/utils/text.ts
@@ -1,0 +1,2 @@
+export const ellipsis = <T, U>(check: T, val: U) =>
+  typeof check == 'undefined' || check == null ? '...' : val


### PR DESCRIPTION
Fixes #87

## Description

This hefty PR reworks the escrow page including various UI elements regarding escrow notice in airdrops fund and register page.

## Changes

List any technical changes.

- [x] update airdrop prop type
- [x] created various utility fns and components
- [x] reworked airdrops escrow page

## Screenshots

**Initial escrow page**

<img width="1552" alt="Screen Shot 2022-03-11 at 04 05 31 AM" src="https://user-images.githubusercontent.com/8220954/157757966-0e1a2bee-38ba-4ed9-87bc-311e776ed8f0.png">

**Incomplete escrow**

<img width="1552" alt="Screen Shot 2022-03-11 at 04 05 07 AM" src="https://user-images.githubusercontent.com/8220954/157758022-51976e63-57fd-48f9-9996-08b12b5483d7.png">

**Processing escrow**

<img width="1552" alt="Screen Shot 2022-03-11 at 04 06 56 AM" src="https://user-images.githubusercontent.com/8220954/157758097-2a6ad120-e421-45dc-b1d2-e05f760345bc.png">

**Intercepted browser close when escrow is processing**

<img width="1440" alt="Screen Shot 2022-03-11 at 04 07 15 AM" src="https://user-images.githubusercontent.com/8220954/157758173-dbffc6af-9fa9-42e8-ab86-46e8d703c29a.png">

**Completed escrow**

<img width="1552" alt="Screen Shot 2022-03-11 at 04 05 41 AM" src="https://user-images.githubusercontent.com/8220954/157758066-4e169c6a-50e4-4c1c-b63c-19efc5afd806.png">

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- use existing cw20 to create airdrop
- proceed to escrow step as usual
- ...

## Links

\-
