### PR TITLE
feat(pages): create airdrop success page

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -37,7 +37,7 @@ declare namespace NodeJS {
 }
 
 declare interface Window {
-  //
+  confetti: any
 }
 
 declare const __DEV__: boolean

--- a/pages/airdrops/fund.tsx
+++ b/pages/airdrops/fund.tsx
@@ -151,7 +151,7 @@ const FundAirdropPage: NextPage = () => {
         }
       )
 
-      router.push(`/airdrops/list`)
+      router.push(`/airdrops/success`)
     } catch (err: any) {
       setLoading(false)
       toast.error(err.message, { style: { maxWidth: 'none' } })

--- a/pages/airdrops/success.tsx
+++ b/pages/airdrops/success.tsx
@@ -1,0 +1,54 @@
+import clsx from 'clsx'
+import Anchor from 'components/Anchor'
+import { NextPage } from 'next'
+import Script from 'next/script'
+import { NextSeo } from 'next-seo'
+import { FaAsterisk, FaCheckCircle } from 'react-icons/fa'
+
+const SuccessAirdropPage: NextPage = () => {
+  return (
+    <>
+      <NextSeo title="Success 🎉" />
+
+      <section className="flex flex-col justify-center items-center space-y-4 max-w-xl text-center">
+        <FaCheckCircle size={96} className="text-plumbus" />
+        <br />
+        <h1 className="text-4xl font-bold">Airdrop created and funded!</h1>
+        <p className="text-lg">
+          Successfully created and funded your airdrop.
+          <br />
+          You can view your airdrop in the airdrops list page.
+        </p>
+        <br />
+        <Anchor
+          href="/airdrops"
+          className={clsx(
+            'flex items-center py-2 px-8 space-x-2 font-bold bg-plumbus-50 hover:bg-plumbus-40 rounded',
+            'transition hover:translate-y-[-2px]'
+          )}
+        >
+          <FaAsterisk />
+          <span>Open Airdrops List</span>
+        </Anchor>
+      </section>
+
+      <Script
+        src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.5.1/dist/confetti.browser.min.js"
+        onLoad={() => {
+          window.confetti({
+            origin: { x: 0, y: 0.5 },
+            particleCount: 250,
+            spread: 500,
+          })
+          window.confetti({
+            origin: { x: 1, y: 0.5 },
+            particleCount: 250,
+            spread: 500,
+          })
+        }}
+      />
+    </>
+  )
+}
+
+export default SuccessAirdropPage


### PR DESCRIPTION
Fixes #65

## Description

This PR implements an airdrop success page for after funding an airdrop is finished.

## Changes

List any technical changes.

- [x] added `/airdrops/success` page
- [x] stubbed `window.confetti` typing
- [x] update airdrop fund success redirect from `/airdrops/list` to `/airdrops/success`

## Screenshots

![](https://cdn.discordapp.com/attachments/933515307597848656/951926595029970984/CleanShot_2022-03-12_at_02.34.44.gif)

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- [x] either fund an airdrop, or
- [x] go to `/airdrops/success` page manually

## Links


\-
