### PR TITLE
refactor(pages): rework airdrop claim page

### DIFF
--- a/contracts/cw20/base/contract.ts
+++ b/contracts/cw20/base/contract.ts
@@ -49,7 +49,7 @@ interface MinterResponse {
   readonly cap?: string
 }
 
-interface TokenInfoResponse {
+export interface TokenInfoResponse {
   readonly name: string
   readonly symbol: string
   readonly decimals: number

--- a/pages/airdrops/[address]/claim.tsx
+++ b/pages/airdrops/[address]/claim.tsx
@@ -155,7 +155,7 @@ const ClaimAirdropPage: NextPage = () => {
         </div>
       )}
 
-      {airdropState == 'not_claimed' && (
+      {(airdropState == 'not_claimed' || airdropState == 'claimed') && (
         <div className="flex flex-col space-y-4">
           <div className="flex items-center space-x-2">
             <h3 className="text-2xl font-bold">{name}</h3>

--- a/pages/airdrops/[address]/claim.tsx
+++ b/pages/airdrops/[address]/claim.tsx
@@ -13,6 +13,13 @@ import { CgSpinnerAlt } from 'react-icons/cg'
 import { FaAsterisk } from 'react-icons/fa'
 import { withMetadata } from 'utils/layout'
 
+type ClaimState =
+  | 'loading'
+  | 'not_claimed'
+  | 'claimed'
+  | 'no_allocation'
+  | 'not_allowed'
+
 const ClaimAirdropPage: NextPage = () => {
   const router = useRouter()
   const wallet = useWallet()
@@ -25,6 +32,8 @@ const ClaimAirdropPage: NextPage = () => {
   const [name, setName] = useState('')
   const [cw20TokenAddress, setCW20TokenAddress] = useState('')
   const [balance, setBalance] = useState(0)
+
+  const [airdropState, setAirdropState] = useState<ClaimState>('loading')
 
   const contractAddress = String(router.query.address)
 

--- a/pages/airdrops/[address]/claim.tsx
+++ b/pages/airdrops/[address]/claim.tsx
@@ -4,7 +4,7 @@ import Alert from 'components/Alert'
 import StackedList from 'components/StackedList'
 import { useContracts } from 'contexts/contracts'
 import { useWallet } from 'contexts/wallet'
-import { GetServerSideProps, NextPage } from 'next'
+import { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { NextSeo } from 'next-seo'
 import { useEffect, useState } from 'react'
@@ -13,23 +13,7 @@ import { CgSpinnerAlt } from 'react-icons/cg'
 import { FaAsterisk } from 'react-icons/fa'
 import { withMetadata } from 'utils/layout'
 
-interface ClaimAirdropPageProps {
-  contractAddress: string
-}
-
-export const getServerSideProps: GetServerSideProps<
-  ClaimAirdropPageProps
-> = async ({ params }) => {
-  return {
-    props: {
-      contractAddress: String(params?.address),
-    },
-  }
-}
-
-const ClaimAirdropPage: NextPage<ClaimAirdropPageProps> = ({
-  contractAddress,
-}) => {
+const ClaimAirdropPage: NextPage = () => {
   const router = useRouter()
   const wallet = useWallet()
   const cw20MerkleAirdropContract = useContracts().cw20MerkleAirdrop
@@ -41,6 +25,8 @@ const ClaimAirdropPage: NextPage<ClaimAirdropPageProps> = ({
   const [name, setName] = useState('')
   const [cw20TokenAddress, setCW20TokenAddress] = useState('')
   const [balance, setBalance] = useState(0)
+
+  const contractAddress = String(router.query.address)
 
   useEffect(() => {
     if (!wallet.initialized) return

--- a/pages/airdrops/[address]/claim.tsx
+++ b/pages/airdrops/[address]/claim.tsx
@@ -1,22 +1,43 @@
 import axios from 'axios'
-import JsonPreview from 'components/JsonPreview'
+import clsx from 'clsx'
+import Alert from 'components/Alert'
+import StackedList from 'components/StackedList'
 import { useContracts } from 'contexts/contracts'
 import { useWallet } from 'contexts/wallet'
+import { GetServerSideProps, NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { NextSeo } from 'next-seo'
 import { useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
+import { CgSpinnerAlt } from 'react-icons/cg'
+import { FaAsterisk } from 'react-icons/fa'
+import { withMetadata } from 'utils/layout'
 
-const ClaimDrop = ({ address }: { address: string }) => {
+interface ClaimAirdropPageProps {
+  contractAddress: string
+}
+
+export const getServerSideProps: GetServerSideProps<
+  ClaimAirdropPageProps
+> = async ({ params }) => {
+  return {
+    props: {
+      contractAddress: String(params?.address),
+    },
+  }
+}
+
+const ClaimAirdropPage: NextPage<ClaimAirdropPageProps> = ({
+  contractAddress,
+}) => {
   const router = useRouter()
-  const contractAddress = address
   const wallet = useWallet()
   const cw20MerkleAirdropContract = useContracts().cw20MerkleAirdrop
   const cw20BaseContract = useContracts().cw20Base
 
   const [amount, setAmount] = useState('')
   const [loading, setLoading] = useState(false)
-  const [proofs, setProofs] = useState<[string]>([''])
+  const [proofs, setProofs] = useState<string[]>([''])
   const [name, setName] = useState('')
   const [cw20TokenAddress, setCW20TokenAddress] = useState('')
   const [balance, setBalance] = useState(0)
@@ -88,44 +109,83 @@ const ClaimDrop = ({ address }: { address: string }) => {
     }
   }
 
-  if (!wallet.initialized) return <div>Please connect your wallet!</div>
-
   return (
-    <div className="w-3/4 h-3/4">
+    <section className="relative py-6 px-12 space-y-8">
       <NextSeo title="Claim Airdrop" />
 
-      <h1 className="mb-20 text-6xl font-bold text-center">{name}</h1>
+      <div className="space-y-4">
+        <h1 className="font-heading text-4xl font-bold">Claim Airdrop</h1>
+        {!wallet.initialized && (
+          <Alert type="warning">
+            No wallet detected. Please connect your wallet before claiming an
+            airdrop.
+          </Alert>
+        )}
+        {wallet.initialized && (
+          <p>
+            Click the claim airdrop button below to add{' '}
+            <b>{amount ?? '...'} juno</b> to your total balance.
+            <br />
+            Your current total token balance is <b>{balance / 1000000} juno</b>.
+          </p>
+        )}
+      </div>
 
-      <h1 className="mb-10 text-3xl font-bold text-center">
-        Your airdrop allocation: {amount} {}
-      </h1>
-      <h1 className="mb-10 text-3xl font-bold text-center">
-        Your token balance: {balance / 1000000} {}
-      </h1>
-      <h1 className="text-lg font-bold text-center">Your merkle proofs:</h1>
-      <JsonPreview title="Merkle Proofs" content={proofs} />
+      {!wallet.initialized && (
+        <div className="flex justify-center items-center p-8 space-x-4 text-xl text-center text-white/50">
+          <CgSpinnerAlt className="animate-spin" />
+          <span>Loading...</span>
+        </div>
+      )}
 
-      <button
-        className={`btn bg-juno border-0 btn-lg hover:bg-juno/80 font-semibold text-2xl w-full mt-4 ${
-          loading ? 'loading' : ''
-        }`}
-        style={{ cursor: loading ? 'not-allowed' : 'pointer' }}
-        disabled={loading}
-        onClick={claim}
-      >
-        Claim Drop
-      </button>
-      <br />
-    </div>
+      {wallet.initialized && (
+        <div className="flex flex-col space-y-4">
+          <div className="flex items-center space-x-2">
+            <h3 className="text-2xl font-bold">{name}</h3>
+            <div className="flex-grow" />
+            <img
+              src="/juno_logo.png"
+              alt="juno"
+              className="w-6 h-6 rounded-full"
+            />
+            <span className="font-bold">{amount} juno</span>
+          </div>
+          <StackedList>
+            <StackedList.Item name="Airdrop Name">{name}</StackedList.Item>
+            <StackedList.Item name="Claim Amount">
+              {amount} juno
+            </StackedList.Item>
+            <StackedList.Item name="Merkle Proofs">
+              <pre className="p-2 text-sm whitespace-pre bg-stone-800/80 rounded">
+                {JSON.stringify(proofs, null, 2)}
+              </pre>
+            </StackedList.Item>
+          </StackedList>
+        </div>
+      )}
+
+      {wallet.initialized && (
+        <div className="flex justify-end pb-6">
+          <button
+            className={clsx(
+              'flex items-center py-2 px-8 space-x-2 font-bold bg-plumbus-50 hover:bg-plumbus-40 rounded',
+              'transition hover:translate-y-[-2px]',
+              { 'animate-pulse cursor-wait pointer-events-none': loading }
+            )}
+            disabled={loading}
+            onClick={claim}
+          >
+            {loading ? (
+              <CgSpinnerAlt className="animate-spin" />
+            ) : (
+              <FaAsterisk />
+            )}
+            <span>Claim Airdrop</span>
+          </button>
+        </div>
+      )}
+    </section>
   )
 }
 
-export async function getServerSideProps({
-  params,
-}: {
-  params: Record<string, string>
-}) {
-  return { props: { address: params.address } }
-}
-
-export default ClaimDrop
+export default withMetadata(ClaimAirdropPage, { center: false })

--- a/pages/airdrops/[address]/claim.tsx
+++ b/pages/airdrops/[address]/claim.tsx
@@ -51,9 +51,9 @@ const ClaimAirdropPage: NextPage = () => {
           setAmount(account.amount.toString())
           setName(airdrop.name)
           setCW20TokenAddress(airdrop.cw20TokenAddress)
+          setAirdropState('not_claimed')
         } else {
           toast.error("You don't have any tokens to claim!")
-          router.push('/airdrops')
         }
       })
       .catch((err: any) => {
@@ -61,6 +61,7 @@ const ClaimAirdropPage: NextPage = () => {
         toast.error(err.message, {
           style: { maxWidth: 'none' },
         })
+        setAirdropState('not_allowed')
       })
   }, [contractAddress, wallet.address, wallet.initialized])
 
@@ -110,30 +111,51 @@ const ClaimAirdropPage: NextPage = () => {
 
       <div className="space-y-4">
         <h1 className="font-heading text-4xl font-bold">Claim Airdrop</h1>
-        {!wallet.initialized && (
+        {airdropState == 'loading' && (
           <Alert type="warning">
             No wallet detected. Please connect your wallet before claiming an
             airdrop.
           </Alert>
         )}
-        {wallet.initialized && (
+        {airdropState == 'no_allocation' && (
+          <Alert type="warning">
+            <b>No allocation.</b>
+            You do not have any claimable tokens for this airdrop address.
+          </Alert>
+        )}
+
+        {airdropState == 'not_claimed' && (
           <p>
             Click the claim airdrop button below to add{' '}
             <b>{amount ?? '...'} juno</b> to your total balance.
-            <br />
+          </p>
+        )}
+
+        {airdropState == 'claimed' && (
+          <p>
+            This airdrop was claimed on
+            {
+              // TODO!: implement actual claimed date
+            }
+            {new Date().toLocaleString()}.
+          </p>
+        )}
+
+        {airdropState != 'loading' && airdropState != 'no_allocation' && (
+          <p>
             Your current total token balance is <b>{balance / 1000000} juno</b>.
           </p>
         )}
       </div>
 
-      {!wallet.initialized && (
+      {airdropState == 'loading' && (
         <div className="flex justify-center items-center p-8 space-x-4 text-xl text-center text-white/50">
           <CgSpinnerAlt className="animate-spin" />
           <span>Loading...</span>
         </div>
       )}
 
-      {wallet.initialized && (
+      {airdropState == 'not_claimed' && (
         <div className="flex flex-col space-y-4">
           <div className="flex items-center space-x-2">
             <h3 className="text-2xl font-bold">{name}</h3>
@@ -159,23 +181,29 @@ const ClaimAirdropPage: NextPage = () => {
         </div>
       )}
 
-      {wallet.initialized && (
+      {airdropState != 'loading' && airdropState != 'no_allocation' && (
         <div className="flex justify-end pb-6">
           <button
             className={clsx(
               'flex items-center py-2 px-8 space-x-2 font-bold bg-plumbus-50 hover:bg-plumbus-40 rounded',
               'transition hover:translate-y-[-2px]',
-              { 'animate-pulse cursor-wait pointer-events-none': loading }
+              {
+                'animate-pulse cursor-wait pointer-events-none': loading,
+                'opacity-50 pointer-events-none': airdropState != 'not_claimed',
+                'bg-green-500': airdropState == 'claimed',
+              }
             )}
-            disabled={loading}
-            onClick={claim}
+            disabled={loading || airdropState != 'not_claimed'}
+            onClick={() => (airdropState != 'not_claimed' ? claim : null)}
           >
             {loading ? (
               <CgSpinnerAlt className="animate-spin" />
             ) : (
               <FaAsterisk />
             )}
-            <span>Claim Airdrop</span>
+            <span>
+              {airdropState == 'claimed' ? 'Airdrop claimed' : 'Claim Airdrop'}
+            </span>
           </button>
         </div>
       )}

--- a/pages/airdrops/[address]/claim.tsx
+++ b/pages/airdrops/[address]/claim.tsx
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import clsx from 'clsx'
 import Alert from 'components/Alert'
+import Conditional from 'components/Conditional'
 import StackedList from 'components/StackedList'
 import { useContracts } from 'contexts/contracts'
 import { useWallet } from 'contexts/wallet'
@@ -13,12 +14,7 @@ import { CgSpinnerAlt } from 'react-icons/cg'
 import { FaAsterisk } from 'react-icons/fa'
 import { withMetadata } from 'utils/layout'
 
-type ClaimState =
-  | 'loading'
-  | 'not_claimed'
-  | 'claimed'
-  | 'no_allocation'
-  | 'not_allowed'
+type ClaimState = 'loading' | 'not_claimed' | 'claimed' | 'no_allocation'
 
 const ClaimAirdropPage: NextPage = () => {
   const router = useRouter()
@@ -38,31 +34,44 @@ const ClaimAirdropPage: NextPage = () => {
   const contractAddress = String(router.query.address)
 
   useEffect(() => {
-    if (!wallet.initialized) return
+    const getAirdropInfo = async () => {
+      try {
+        if (!wallet.initialized || contractAddress === '') return
 
-    axios
-      .get(
-        `${process.env.NEXT_PUBLIC_API_URL}/proofs/contract/${contractAddress}/wallet/${wallet.address}`
-      )
-      .then(({ data }) => {
+        const merkleAirdropContractMessages =
+          cw20MerkleAirdropContract?.use(contractAddress)
+
+        const { data } = await axios.get(
+          `${process.env.NEXT_PUBLIC_API_URL}/proofs/contract/${contractAddress}/wallet/${wallet.address}`
+        )
+
         const { account, airdrop } = data
         if (account) {
+          const stage = await merkleAirdropContractMessages?.getLatestStage()
+          const isClaimed = await merkleAirdropContractMessages?.isClaimed(
+            wallet.address,
+            stage || 0
+          )
+
           setProofs(account.proofs)
           setAmount(account.amount.toString())
           setName(airdrop.name)
           setCW20TokenAddress(airdrop.cw20TokenAddress)
-          setAirdropState('not_claimed')
+
+          if (isClaimed) setAirdropState('claimed')
+          else setAirdropState('not_claimed')
         } else {
-          toast.error("You don't have any tokens to claim!")
+          setAirdropState('no_allocation')
         }
-      })
-      .catch((err: any) => {
+      } catch (err: any) {
         setLoading(false)
         toast.error(err.message, {
           style: { maxWidth: 'none' },
         })
-        setAirdropState('not_allowed')
-      })
+      }
+    }
+
+    getAirdropInfo()
   }, [contractAddress, wallet.address, wallet.initialized])
 
   useEffect(() => {
@@ -93,7 +102,8 @@ const ClaimAirdropPage: NextPage = () => {
       await contractMessages?.claim(wallet.address, stage || 0, amount, proofs)
 
       setLoading(false)
-      toast.success('Success!', {
+      setAirdropState('claimed')
+      toast.success('Successfully claimed the airdrop!', {
         style: { maxWidth: 'none' },
       })
       setBalance(balance + parseInt(amount))
@@ -111,51 +121,28 @@ const ClaimAirdropPage: NextPage = () => {
 
       <div className="space-y-4">
         <h1 className="font-heading text-4xl font-bold">Claim Airdrop</h1>
-        {airdropState == 'loading' && (
+        <Conditional test={!wallet.initialized}>
           <Alert type="warning">
             No wallet detected. Please connect your wallet before claiming an
             airdrop.
           </Alert>
-        )}
-        {airdropState == 'no_allocation' && (
-          <Alert type="warning">
-            <b>No allocation.</b>
-            You do not have any claimable tokens for this airdrop address.
-          </Alert>
-        )}
-
-        {airdropState == 'not_claimed' && (
-          <p>
-            Click the claim airdrop button below to add{' '}
-            <b>{amount ?? '...'} juno</b> to your total balance.
-          </p>
-        )}
-
-        {airdropState == 'claimed' && (
-          <p>
-            This airdrop was claimed on{' '}
-            {
-              // TODO!: implement actual claimed date
-            }
-            {new Date().toLocaleString()}.
-          </p>
-        )}
-
-        {airdropState != 'loading' && airdropState != 'no_allocation' && (
-          <p>
-            Your current total token balance is <b>{balance / 1000000} juno</b>.
-          </p>
-        )}
+        </Conditional>
+        <Conditional test={wallet.initialized}>
+          {airdropState == 'no_allocation' && (
+            <Alert type="warning">
+              <b>No allocation.</b>
+              You do not have any claimable tokens for this airdrop address.
+            </Alert>
+          )}
+        </Conditional>
       </div>
 
-      {airdropState == 'loading' && (
-        <div className="flex justify-center items-center p-8 space-x-4 text-xl text-center text-white/50">
-          <CgSpinnerAlt className="animate-spin" />
-          <span>Loading...</span>
-        </div>
-      )}
-
-      {(airdropState == 'not_claimed' || airdropState == 'claimed') && (
+      <Conditional
+        test={
+          wallet.initialized &&
+          (airdropState === 'not_claimed' || airdropState == 'claimed')
+        }
+      >
         <div className="flex flex-col space-y-4">
           <div className="flex items-center space-x-2">
             <h3 className="text-2xl font-bold">{name}</h3>
@@ -165,12 +152,21 @@ const ClaimAirdropPage: NextPage = () => {
               alt="juno"
               className="w-6 h-6 rounded-full"
             />
-            <span className="font-bold">{amount} juno</span>
+            <span className="font-bold">{parseInt(amount) / 1000000} juno</span>
           </div>
           <StackedList>
             <StackedList.Item name="Airdrop Name">{name}</StackedList.Item>
+            <StackedList.Item name="Airdrop Contract Address">
+              {contractAddress}
+            </StackedList.Item>
+            <StackedList.Item name="Airdrop CW20 Token Address">
+              {cw20TokenAddress}
+            </StackedList.Item>
             <StackedList.Item name="Claim Amount">
-              {amount} juno
+              {parseInt(amount) / 1000000} juno
+            </StackedList.Item>
+            <StackedList.Item name="Your CW20 Balance">
+              {balance / 1000000} juno
             </StackedList.Item>
             <StackedList.Item name="Merkle Proofs">
               <pre className="overflow-auto p-2 text-sm bg-stone-800/80 rounded">
@@ -179,9 +175,9 @@ const ClaimAirdropPage: NextPage = () => {
             </StackedList.Item>
           </StackedList>
         </div>
-      )}
+      </Conditional>
 
-      {airdropState != 'loading' && airdropState != 'no_allocation' && (
+      <Conditional test={wallet.initialized}>
         <div className="flex justify-end pb-6">
           <button
             className={clsx(
@@ -194,7 +190,7 @@ const ClaimAirdropPage: NextPage = () => {
               }
             )}
             disabled={loading || airdropState != 'not_claimed'}
-            onClick={() => (airdropState != 'not_claimed' ? claim : null)}
+            onClick={claim}
           >
             {loading ? (
               <CgSpinnerAlt className="animate-spin" />
@@ -202,11 +198,11 @@ const ClaimAirdropPage: NextPage = () => {
               <FaAsterisk />
             )}
             <span>
-              {airdropState == 'claimed' ? 'Airdrop claimed' : 'Claim Airdrop'}
+              {airdropState == 'claimed' ? 'Airdrop Claimed' : 'Claim Airdrop'}
             </span>
           </button>
         </div>
-      )}
+      </Conditional>
     </section>
   )
 }

--- a/pages/airdrops/[address]/claim.tsx
+++ b/pages/airdrops/[address]/claim.tsx
@@ -53,7 +53,7 @@ const ClaimAirdropPage: NextPage = () => {
           style: { maxWidth: 'none' },
         })
       })
-  }, [wallet.address])
+  }, [contractAddress, wallet.address, wallet.initialized])
 
   useEffect(() => {
     if (!cw20BaseContract || !cw20TokenAddress) return
@@ -66,7 +66,7 @@ const ClaimAirdropPage: NextPage = () => {
         setBalance(parseInt(data))
       })
       .catch((err) => {})
-  }, [cw20BaseContract, cw20TokenAddress])
+  }, [cw20BaseContract, cw20TokenAddress, wallet.address])
 
   const claim = async () => {
     try {

--- a/pages/airdrops/[address]/claim.tsx
+++ b/pages/airdrops/[address]/claim.tsx
@@ -133,7 +133,7 @@ const ClaimAirdropPage: NextPage = () => {
 
         {airdropState == 'claimed' && (
           <p>
-            This airdrop was claimed on
+            This airdrop was claimed on{' '}
             {
               // TODO!: implement actual claimed date
             }
@@ -173,7 +173,7 @@ const ClaimAirdropPage: NextPage = () => {
               {amount} juno
             </StackedList.Item>
             <StackedList.Item name="Merkle Proofs">
-              <pre className="p-2 text-sm whitespace-pre bg-stone-800/80 rounded">
+              <pre className="overflow-auto p-2 text-sm bg-stone-800/80 rounded">
                 {JSON.stringify(proofs, null, 2)}
               </pre>
             </StackedList.Item>


### PR DESCRIPTION
Fixes #104

## Description

This PR reworks the airdrop claim page.

## Changes

List any technical changes.

- [x] rework page base stylings
- [x] implement various airdrop claim conditions

## Screenshots

**Loading**

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/8220954/159799827-00a45de5-98b7-4e30-b604-f45fcb6341b9.png">

**Not claimed**

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/8220954/159800147-0571a317-f420-4f1f-bab9-110e4f52f345.png">

**Claimed**

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/8220954/159800264-1812d1ff-76c5-4081-8320-26340507d705.png">

**No allocation**

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/8220954/159800313-6598222e-9637-4c92-a6f1-c3a91217557a.png">

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- Check various airdrops with different states (unclaimable, claimed, etc.)

## Links

\-
