### PR TITLE
feat(hooks): add useDevAssignWindow hook

### DIFF
--- a/hooks/useDevAssignWindow.ts
+++ b/hooks/useDevAssignWindow.ts
@@ -1,0 +1,10 @@
+import { useEffect } from 'react'
+
+export const useDevAssignWindow = (obj: Record<string, unknown>) => {
+  useEffect(() => {
+    if (!__DEV__) return
+
+    Object.assign(window, obj)
+    return () => Object.keys(obj).forEach((k: any) => delete window[k])
+  }, [obj])
+}


### PR DESCRIPTION
## Description

This PR adds a dev-only hook to assign any custom value in `window`, meaning it will only run in development mode.

## Changes

List any technical changes.

- [x] add `useDevAssignWindow` hook

## Screenshots

- https://github.com/CosmosContracts/juno-tools/pull/106#issue-1177292495

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- register state setters in `window`
  
  ```js
  const [count, setCount] = useState(0)
  useDevAssignWindow({ setCount })
  ```

- open browser console and use state setter in `window`

  ```js
  window.setCount(1)
  ```

- make sure in production build that given property is not assigned in `window`

## Links

\-
