### PR TITLE
fix(ui): update airdrops stepper color

### DIFF
--- a/components/AirdropsStepper.tsx
+++ b/components/AirdropsStepper.tsx
@@ -41,11 +41,13 @@ const AirdropsStepper = (props: AirdropsStepperProps) => {
             href={href}
             className={clsx(
               'group flex relative justify-center items-center w-10 h-10 rounded-full',
-              'border-2 border-plumbus-40',
-              i < step ? 'bg-plumbus-60' : 'bg-transparent hover:bg-plumbus/25'
+              'border-2 border-plumbus',
+              i < step ? 'bg-plumbus' : 'bg-transparent hover:bg-plumbus/25'
             )}
           >
-            <span className="font-bold">{i + 1}</span>
+            <span className={clsx('font-bold', { 'text-black': i < step })}>
+              {i + 1}
+            </span>
             <span
               className={clsx(
                 'absolute -bottom-8 pt-4 text-sm group-hover:underline',

--- a/components/AirdropsStepper.tsx
+++ b/components/AirdropsStepper.tsx
@@ -41,8 +41,8 @@ const AirdropsStepper = (props: AirdropsStepperProps) => {
             href={href}
             className={clsx(
               'group flex relative justify-center items-center w-10 h-10 rounded-full',
-              'border-2 border-plumbus',
-              i < step ? 'bg-plumbus' : 'bg-transparent hover:bg-plumbus/25'
+              'border-2 border-plumbus-40',
+              i < step ? 'bg-plumbus-60' : 'bg-transparent hover:bg-plumbus/25'
             )}
           >
             <span className="font-bold">{i + 1}</span>


### PR DESCRIPTION
Fixes #105

## Description

This PR updates the airdrops stepper styling to improve a11y on active step.

## Changes

List any technical changes.

- [x] update stepper colors

## Screenshots

![CleanShot 2022-03-29 at 23 31 01](https://user-images.githubusercontent.com/8220954/160660899-9ec2e574-04db-46a8-b363-66651947d215.gif)

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- open any airdrop create step page

## Links

\-
