### PR TITLE
feat(ui): override default datetime icons

### DIFF
--- a/components/InputDateTime.tsx
+++ b/components/InputDateTime.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx'
 import DateTimePicker, {
   DateTimePickerProps,
 } from 'react-datetime-picker/dist/entry.nostyle'
+import { FaCalendar, FaTimes } from 'react-icons/fa'
 
 const InputDateTime = ({ className, ...rest }: DateTimePickerProps) => {
   return (
@@ -12,6 +13,8 @@ const InputDateTime = ({ className, ...rest }: DateTimePickerProps) => {
         'focus:ring focus:ring-plumbus-20',
         className
       )}
+      clearIcon={<FaTimes className="text-plumbus-40 hover:text-plumbus-60" />}
+      calendarIcon={<FaCalendar className="text-white hover:text-white/80" />}
       {...rest}
     />
   )


### PR DESCRIPTION
Fixes #61

## Description

This PR resolves #61 by overriding the default date time icon buttons.

## Changes

List any technical changes.

- [x] override default datetime icons

## Screenshots

<img width="506" alt="image" src="https://user-images.githubusercontent.com/8220954/160478927-b9125859-61c3-4f66-9d84-34b45df2c26f.png">

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- http://localhost:3000/airdrops/create/

## Links

\-
