### PR TITLE
fix(pages): resolve airdrops row hover styling

### DIFF
--- a/components/AirdropsTable.tsx
+++ b/components/AirdropsTable.tsx
@@ -101,16 +101,13 @@ const AirdropsTable = ({ data, className, ...rest }: AirdropsTableProps) => {
               <td className="p-4">
                 {getAirdropDate(airdrop.expiration, airdrop.expirationType)}
               </td>
-              <td
-                className={clsx('p-4', {
-                  hidden: !wallet.address || !airdrop.allocation,
-                })}
-              >
+              <td className="p-4">
                 <button
                   className={clsx(
                     'font-bold text-plumbus uppercase',
                     'py-1 px-4 rounded border border-plumbus',
-                    'bg-plumbus/10 hover:bg-plumbus/20'
+                    'bg-plumbus/10 hover:bg-plumbus/20',
+                    { hidden: !wallet.address || !airdrop.allocation }
                   )}
                   onClick={() => claimOnClick(airdrop.contractAddress)}
                 >


### PR DESCRIPTION
Fixes #63

## Description

This PR fixes #63 by hiding the button instead of the column itself.

## Changes

List any technical changes.

- [x] handle airdrop list hidden column logic

## Screenshots

![CleanShot 2022-03-29 at 03 14 15](https://user-images.githubusercontent.com/8220954/160479491-d6c88b50-ff94-43db-b012-c6ed4c4977a3.gif)

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- http://localhost:3000/airdrops/ and hover on rows

## Links

\-
