### PR TITLE
fix(ui): resolve airdrop avatar images get squished at small widths

### DIFF
--- a/components/AirdropsTable.tsx
+++ b/components/AirdropsTable.tsx
@@ -68,11 +68,13 @@ const AirdropsTable = ({ data, className, ...rest }: AirdropsTableProps) => {
             >
               <td className="p-4">
                 <div className="flex items-center space-x-4 font-medium">
-                  <img
-                    src={airdrop.logo?.url ?? '/juno_logo.png'}
-                    alt={airdrop.name}
-                    className="overflow-hidden w-8 h-8 bg-plumbus rounded-full"
-                  />
+                  <div className="w-8 min-w-max h-8 min-h-max">
+                    <img
+                      src={airdrop.logo?.url ?? '/juno_logo.png'}
+                      alt={airdrop.name}
+                      className="overflow-hidden w-8 h-8 bg-plumbus rounded-full"
+                    />
+                  </div>
                   <div>
                     <div>{airdrop.name}</div>
                     <Tooltip label="Click to copy wallet addreess">


### PR DESCRIPTION
Fixes #62

## Description

This PR fixes #62 by setting a fixed size for the airdrops list item image.

## Changes

List any technical changes.

- [x] set airdrop list item fixed image size

## Screenshots

Somehow it won't upload, so here's a hosted gif recording: https://cln.sh/MJ4PVA

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- http://localhost:3000/airdrops/ and resize window horizontally

## Links

\-
