### PR TITLE
fix(ui): use extra wrapper for layout max-width

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -36,17 +36,16 @@ const Layout = ({ children, metadata = {} }: LayoutProps) => {
       {/* actual layout container */}
       <div className="hidden sm:flex">
         <Sidebar />
-        <main
-          className={clsx(
-            'overflow-auto relative mx-auto w-full max-w-7xl h-screen',
-            {
+        <div className="overflow-auto relative flex-grow h-screen">
+          <main
+            className={clsx('mx-auto max-w-7xl', {
               'flex flex-col justify-center items-center':
                 typeof metadata.center == 'boolean' ? metadata.center : true,
-            }
-          )}
-        >
-          {children}
-        </main>
+            })}
+          >
+            {children}
+          </main>
+        </div>
       </div>
 
       <div className="flex flex-col justify-center items-center p-8 space-y-4 h-screen text-center bg-black/50 sm:hidden">


### PR DESCRIPTION
Fixes #120

## Description

This PR resolves #120 by adding another wrapper for layout max-width.

## Changes

List any technical changes.

- [x] use extra wrapper for layout max-width

## Screenshots

<img width="1972" alt="image" src="https://user-images.githubusercontent.com/8220954/160671057-23025ff5-3995-44f2-9d81-160e5806130e.png">

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- open any page with long contents and make sure the scroll bar is at the rightmost screen

## Links

\-
