### PR TITLE
fix(ui): remove useless wallet loader fragment

### DIFF
--- a/components/WalletLoader.tsx
+++ b/components/WalletLoader.tsx
@@ -71,12 +71,10 @@ export const WalletLoader: VFC = () => {
                 </span>
                 <div className="font-bold">Your Balances</div>
                 {balance.map((val) => (
-                  <>
-                    <span key={`balance-${val.denom}`}>
-                      {Number(val.amount) / 1000000}{' '}
-                      {val.denom.slice(1, val.denom.length)}
-                    </span>
-                  </>
+                  <span key={`balance-${val.denom}`}>
+                    {Number(val.amount) / 1000000}{' '}
+                    {val.denom.slice(1, val.denom.length)}
+                  </span>
                 ))}
               </div>
               <WalletPanelButton Icon={FaCopy} onClick={() => copy(address)}>


### PR DESCRIPTION
## Description

This PR removes a useless fragment component in wallet loader.

## Changes

List any technical changes.

- [x] [remove useless wallet loader fragment](https://github.com/CosmosContracts/juno-tools/commit/65a3a7e4703eb76169d66317478ea3fafe17099e)

## Screenshots

**Before removing fragment console error**

<img width="438" alt="image" src="https://user-images.githubusercontent.com/8220954/162274204-2238810b-a089-42c2-b38c-7703111a6f67.png">

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

\-

## Links

\-
