### PR TITLE
Query without wallet

### DIFF
--- a/contexts/contracts.tsx
+++ b/contexts/contracts.tsx
@@ -1,5 +1,5 @@
-import type { UseCW1SubkeysContractProps } from 'contracts/cw1/subkeys'
-import { useCW1SubkeysContract } from 'contracts/cw1/subkeys'
+import type { UseCW1SubkeysContractProps, UseCW1SubkeysContractQueryProps } from 'contracts/cw1/subkeys'
+import { useCW1SubkeysContract, useCW1SubkeysContractQuery } from 'contracts/cw1/subkeys'
 import type { UseCW20BaseContractProps } from 'contracts/cw20/base'
 import { useCW20BaseContract } from 'contracts/cw20/base'
 import type { UseCW20BondingContractProps } from 'contracts/cw20/bonding'
@@ -24,6 +24,7 @@ export interface ContractsStore extends State {
   cw20Staking: UseCW20StakingContractProps | null
   cw20MerkleAirdrop: UseCW20MerkleAirdropContractProps | null
   cw1Subkeys: UseCW1SubkeysContractProps | null
+  cw1SubkeysQuery: UseCW1SubkeysContractQueryProps | null
   cw721Base: UseCW721BaseContractProps | null
 }
 
@@ -36,6 +37,7 @@ export const defaultValues: ContractsStore = {
   cw20Staking: null,
   cw20MerkleAirdrop: null,
   cw1Subkeys: null,
+  cw1SubkeysQuery: null,
   cw721Base: null,
 }
 
@@ -70,6 +72,7 @@ const ContractsSubscription = () => {
   const cw20Staking = useCW20StakingContract()
   const cw20MerkleAirdrop = useCW20MerkleAirdropContract()
   const cw1Subkeys = useCW1SubkeysContract()
+  const cw1SubkeysQuery = useCW1SubkeysContractQuery()
   const cw721Base = useCW721BaseContract()
 
   useEffect(() => {
@@ -79,6 +82,7 @@ const ContractsSubscription = () => {
       cw20Staking,
       cw20MerkleAirdrop,
       cw1Subkeys,
+      cw1SubkeysQuery,
       cw721Base,
     })
   }, [
@@ -87,6 +91,7 @@ const ContractsSubscription = () => {
     cw20Staking,
     cw20MerkleAirdrop,
     cw1Subkeys,
+    cw1SubkeysQuery,
     cw721Base,
     //
   ])

--- a/contracts/cw1/subkeys/contract.ts
+++ b/contracts/cw1/subkeys/contract.ts
@@ -393,41 +393,41 @@ export const CW1SubkeysExecute = (client: SigningCosmWasmClient, txSigner: strin
   return { use, instantiate, messages }
 }
 
-export const CW1SubkeysQuery = (client: CosmWasmClient): CW1SubkeysContractQuery => {
+export const CW1SubkeysQuery = (client: CosmWasmClient | undefined): CW1SubkeysContractQuery => {
   const use = (contractAddress: string): CW1SubkeysInstanceQuery => {
     const allowance = async (address?: string) => {
-      return client.queryContractSmart(contractAddress, {
+      return client?.queryContractSmart(contractAddress, {
         allowance: { spender: address },
       }) as Promise<AllowanceInfo>
     }
 
     const allAllowances = async (startAfter?: string, limit?: number) => {
-      return client.queryContractSmart(contractAddress, {
+      return client?.queryContractSmart(contractAddress, {
         all_allowances: { start_after: startAfter, limit },
       }) as Promise<AllAllowancesResponse>
     }
 
     const permissions = async (address?: string) => {
-      return client.queryContractSmart(contractAddress, {
+      return client?.queryContractSmart(contractAddress, {
         permissions: { spender: address },
       }) as Promise<PermissionsInfo>
     }
 
     const allPermissions = async (startAfter?: string, limit?: number) => {
-      return client.queryContractSmart(contractAddress, {
+      return client?.queryContractSmart(contractAddress, {
         all_permissions: { start_after: startAfter, limit },
       }) as Promise<AllPermissionsResponse>
     }
 
     const canExecute = async (sender: string, msg: CosmosMsg) => {
-      return client.queryContractSmart(contractAddress, {
+      return client?.queryContractSmart(contractAddress, {
         can_execute: { sender, msg },
       }) as Promise<CanExecuteResponse>
     }
 
     const admins = async () => {
-      console.log('bı')
-      return client.queryContractSmart(contractAddress, { admin_list: {} }) as Promise<AdminListResponse>
+      console.log('bı', client, contractAddress)
+      return client?.queryContractSmart(contractAddress, { admin_list: {} }) as Promise<AdminListResponse>
     }
 
     return {

--- a/contracts/cw1/subkeys/useContract.ts
+++ b/contracts/cw1/subkeys/useContract.ts
@@ -1,8 +1,14 @@
 import { useWallet } from 'contexts/wallet'
 import { useCallback, useEffect, useState } from 'react'
 
-import type { CW1SubkeysContract, CW1SubkeysInstance, CW1SubkeysMessages } from './contract'
-import { CW1Subkeys as initContract } from './contract'
+import type {
+  CW1SubkeysContract,
+  CW1SubkeysContractQuery,
+  CW1SubkeysInstance,
+  CW1SubkeysInstanceQuery,
+  CW1SubkeysMessages,
+} from './contract'
+import { CW1SubkeysExecute as initContract } from './contract'
 
 interface InstantiateResponse {
   readonly contractAddress: string
@@ -19,6 +25,10 @@ export interface UseCW1SubkeysContractProps {
   use: (customAddress: string) => CW1SubkeysInstance | undefined
   updateContractAddress: (contractAddress: string) => void
   messages: () => CW1SubkeysMessages | undefined
+}
+
+export interface UseCW1SubkeysContractQueryProps {
+  use: (customAddress: string) => CW1SubkeysInstanceQuery | undefined
 }
 
 export function useCW1SubkeysContract(): UseCW1SubkeysContractProps {
@@ -71,5 +81,22 @@ export function useCW1SubkeysContract(): UseCW1SubkeysContractProps {
     use,
     updateContractAddress,
     messages,
+  }
+}
+
+export function useCW1SubkeysContractQuery(): UseCW1SubkeysContractQueryProps {
+  const [address, setAddress] = useState<string>('')
+  const [CW1SubkeysQuery, setCW1SubkeysQuery] = useState<CW1SubkeysContractQuery>()
+  //const client = CosmWasmClient.queryClient
+  useEffect(() => {
+    setAddress(localStorage.getItem('contract_address') || '')
+  }, [])
+
+  const use = useCallback((customAddress = ''): CW1SubkeysInstanceQuery | undefined => {
+    return CW1SubkeysQuery?.use(address || customAddress)
+  }, [])
+
+  return {
+    use,
   }
 }

--- a/contracts/cw1/subkeys/useContract.ts
+++ b/contracts/cw1/subkeys/useContract.ts
@@ -1,3 +1,4 @@
+import { CosmWasmClient } from '@cosmjs/cosmwasm-stargate/build/cosmwasmclient'
 import { useWallet } from 'contexts/wallet'
 import { useCallback, useEffect, useState } from 'react'
 
@@ -8,7 +9,7 @@ import type {
   CW1SubkeysInstanceQuery,
   CW1SubkeysMessages,
 } from './contract'
-import { CW1SubkeysExecute as initContract } from './contract'
+import { CW1SubkeysExecute as initContract, CW1SubkeysQuery as finitContract } from './contract'
 
 interface InstantiateResponse {
   readonly contractAddress: string
@@ -87,14 +88,34 @@ export function useCW1SubkeysContract(): UseCW1SubkeysContractProps {
 export function useCW1SubkeysContractQuery(): UseCW1SubkeysContractQueryProps {
   const [address, setAddress] = useState<string>('')
   const [CW1SubkeysQuery, setCW1SubkeysQuery] = useState<CW1SubkeysContractQuery>()
-  //const client = CosmWasmClient.queryClient
+
+  useEffect(() => {
+    const getClient = async () => {
+      const client = await CosmWasmClient.connect('https://rpc.uni.juno.deuslabs.fi')
+      return client
+    }
+    getClient().then(
+      (client) => {
+        console.log(client)
+        const cw20BaseContract = finitContract(client)
+        setCW1SubkeysQuery(cw20BaseContract)
+      },
+      (reason) => {
+        console.log(reason)
+      },
+    )
+  }, [])
+
   useEffect(() => {
     setAddress(localStorage.getItem('contract_address') || '')
   }, [])
 
-  const use = useCallback((customAddress = ''): CW1SubkeysInstanceQuery | undefined => {
-    return CW1SubkeysQuery?.use(address || customAddress)
-  }, [])
+  const use = useCallback(
+    (customAddress = ''): CW1SubkeysInstanceQuery | undefined => {
+      return CW1SubkeysQuery?.use(address || customAddress)
+    },
+    [CW1SubkeysQuery],
+  )
 
   return {
     use,

--- a/pages/contracts/cw1/subkeys/query.tsx
+++ b/pages/contracts/cw1/subkeys/query.tsx
@@ -22,7 +22,7 @@ import { withMetadata } from 'utils/layout'
 import { links } from 'utils/links'
 
 const CW1SubkeysQueryPage: NextPage = () => {
-  const { cw1Subkeys: contract } = useContracts()
+  const { cw1SubkeysQuery: contract } = useContracts()
   const wallet = useWallet()
 
   const contractState = useInputState({
@@ -60,7 +60,7 @@ const CW1SubkeysQueryPage: NextPage = () => {
       const messages = contract?.use(_address)
       // eslint-disable-next-line @typescript-eslint/no-shadow
       const ownerAddress = _ownerAddress || _wallet.address
-
+      console.log('aa', messages, _address)
       const result = await dispatchQuery({
         ownerAddress,
         canExecuteMessage: JSON.parse(messageState.value),

--- a/pages/contracts/cw1/subkeys/query.tsx
+++ b/pages/contracts/cw1/subkeys/query.tsx
@@ -60,7 +60,6 @@ const CW1SubkeysQueryPage: NextPage = () => {
       const messages = contract?.use(_address)
       // eslint-disable-next-line @typescript-eslint/no-shadow
       const ownerAddress = _ownerAddress || _wallet.address
-      console.log('aa', messages, _address)
       const result = await dispatchQuery({
         ownerAddress,
         canExecuteMessage: JSON.parse(messageState.value),

--- a/utils/contracts/cw1/subkeys/query.ts
+++ b/utils/contracts/cw1/subkeys/query.ts
@@ -1,4 +1,4 @@
-import type { CosmosMsg, CW1SubkeysInstance } from 'contracts/cw1/subkeys'
+import type { CosmosMsg, CW1SubkeysInstanceQuery } from 'contracts/cw1/subkeys'
 
 export type QueryType = typeof QUERY_TYPES[number]
 
@@ -29,7 +29,7 @@ export const QUERY_LIST: QueryListItem[] = [
 export interface DispatchQueryProps {
   ownerAddress: string
   canExecuteMessage: CosmosMsg
-  messages: CW1SubkeysInstance | undefined
+  messages: CW1SubkeysInstanceQuery | undefined
   type: QueryType
 }
 


### PR DESCRIPTION
CW1Subkeys, in contract.ts, divided into two different functions as an example:

CW1SubkeysExecute for Execute operations, gets SigningCosmWasmClient as an argument

CW1SubkeysQuery for Query operations, gets CosmWasmClient as an argument