### PR TITLE
Fix keplr wallet connection issue & update testnet chainId

### DIFF
--- a/config/keplr.ts
+++ b/config/keplr.ts
@@ -52,11 +52,6 @@ export const keplrConfig = (config: AppConfig): ChainInfo => ({
       coinMinimalDenom: config.feeToken,
       coinDecimals: config.coinMap[config.feeToken].fractionalDigits,
     },
-    {
-      coinDenom: config.coinMap[config.stakingToken].denom,
-      coinMinimalDenom: config.stakingToken,
-      coinDecimals: config.coinMap[config.stakingToken].fractionalDigits,
-    },
   ],
   feeCurrencies: [
     {

--- a/config/network.ts
+++ b/config/network.ts
@@ -20,7 +20,7 @@ export const mainnetConfig: AppConfig = {
 }
 
 export const uniTestnetConfig: AppConfig = {
-  chainId: 'uni-3',
+  chainId: 'uni-5',
   chainName: 'Uni',
   addressPrefix: 'juno',
   rpcUrl: 'https://rpc.uni.juno.deuslabs.fi',


### PR DESCRIPTION
Keplr Wallet doesn't like having duplicate currencies (i.e., feeToken: ujunox, stakingToken: ujunox) anymore.

The issue affects newcomers adding the uni testnet to their list of chains for the first time.

![Screenshot from 2022-09-27 07-54-55](https://user-images.githubusercontent.com/11138024/192436449-fc30ea81-24e2-488f-8674-e77a6cbb3c13.png)
